### PR TITLE
feat: Table Header opacity

### DIFF
--- a/src/components/ImageSearchResultTable.tsx
+++ b/src/components/ImageSearchResultTable.tsx
@@ -99,8 +99,8 @@ export const columns: ColumnDef<SearchableImageWithGameCard>[] = [
     sortUndefined: 1,
     header: () => "Battler Health",
     sortingFn: (rowA, rowB) => {
-      const numA = rowA.original.gameCard?.battlerHealth ?? -1;
-      const numB = rowB.original.gameCard?.battlerHealth ?? -1;
+      const numA = rowA.original.gameCard?.battlerHealth ;
+      const numB = rowB.original.gameCard?.battlerHealth ;
       return numA - numB;
     },
   },
@@ -111,8 +111,8 @@ export const columns: ColumnDef<SearchableImageWithGameCard>[] = [
     sortUndefined: 1,
     header: () => "Battler Power",
     sortingFn: (rowA, rowB) => {
-      const numA = rowA.original.gameCard?.battlerPower ?? -1;
-      const numB = rowB.original.gameCard?.battlerPower ?? -1;
+      const numA = rowA.original.gameCard?.battlerPower ;
+      const numB = rowB.original.gameCard?.battlerPower ;
       return numA - numB;
     },
   },
@@ -274,7 +274,7 @@ export function ImageSearchResultTable() {
       </div>
       <div className="rounded-md border">
         <Table>
-          <TableHeader>
+          <TableHeader style={{ backgroundColor: 'hsla(0, 0%, 100%, 0.3)' }}>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {


### PR DESCRIPTION
Stuck with the HSL format for adding a slightly opaque table header.

Also removed the default -1 for the Battle Health/Battle Power which prevents the `sortUndefined` from working as expected.

I do kind of like the more muted 10%, but am leaving that up to you:
`          <TableHeader style={{ backgroundColor: 'hsla(0, 0%, 100%, 0.1)' }}>`